### PR TITLE
Fix documentation link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.3.0"
 description = "Do two directories have different contents?"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/steveklabnik/dir-diff"
-documentation = "https://docs.rs/dir-diff"
+documentation = "https://docs.rs/crate/dir-diff"
 readme = "README.md"
 tags = ["directory", "diff", "fs"]
 


### PR DESCRIPTION
I am not sure if the previous link ever worked, but I would hope that docs.rs didn't just change the URL format. If that's the case, I should better fix the links of my crates too :D.